### PR TITLE
Run generate to populate pack2 code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.13.4 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-os-coreos-alicloud
 COPY . .
-RUN make install
+RUN make install-requirements && make generate && make install
 
 ############# gardener-extension-os-coreos-alicloud
 FROM alpine:3.11.3 AS gardener-extension-os-coreos-alicloud


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the controller fails with:
```
$ k -n extension-os-coreos-alicloud-zrxcb logs gardener-extension-os-coreos-alicloud-5f595b8dcb-zj8md
panic: stat /templates/cloud-init.sh.template: no such file or directory

goroutine 1 [running]:
k8s.io/apimachinery/pkg/util/runtime.Must(...)
	/go/src/github.com/gardener/gardener-extension-os-coreos-alicloud/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:171
github.com/gardener/gardener-extension-os-coreos-alicloud/pkg/coreos-alicloud/internal.init.0()
	/go/src/github.com/gardener/gardener-extension-os-coreos-alicloud/pkg/coreos-alicloud/internal/template_generator.go:39 +0x287
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
