### PR TITLE
Add deprecation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 [![CI Build status](https://concourse.ci.gardener.cloud/api/v1/teams/gardener/pipelines/gardener-extension-os-coreos-alicloud-master/jobs/master-head-update-job/badge)](https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-extension-os-coreos-alicloud-master/jobs/master-head-update-job)
 [![Go Report Card](https://goreportcard.com/badge/github.com/gardener/gardener-extension-os-coreos-alicloud)](https://goreportcard.com/report/github.com/gardener/gardener-extension-os-coreos-alicloud)
 
+## Deprecation Note
+
+:warning: This repository is not actively maintained anymore due to the fact that CoreOS has been deprecated and no longer available on Alicloud.
+
+## How does it work
+
 Project Gardener implements the automated management and operation of [Kubernetes](https://kubernetes.io/) clusters as a service. Its main principle is to leverage Kubernetes concepts for all of its tasks.
 
 Recently, most of the vendor specific logic has been developed [in-tree](https://github.com/gardener/gardener). However, the project has grown to a size where it is very hard to extend, maintain, and test. With [GEP-1](https://github.com/gardener/gardener/blob/master/docs/proposals/01-extensibility.md) we have proposed how the architecture can be changed in a way to support external controllers that contain their very own vendor specifics. This way, we can keep Gardener core clean and independent.


### PR DESCRIPTION
**What this PR does / why we need it**:
Deprecate this extension as CoreOS is no longer available on Alicloud.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Once this pr is merged, this repo can be archived and moved to https://github.com/gardener-attic

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
